### PR TITLE
Update case attribute probability input to allow decimals

### DIFF
--- a/frontend/pix-web-ui/app/routes/projects.$projectId.$processingType/components/prosimos/TabCaseAttributes.tsx
+++ b/frontend/pix-web-ui/app/routes/projects.$projectId.$processingType/components/prosimos/TabCaseAttributes.tsx
@@ -93,7 +93,7 @@ function CaseAttribute({ name, children }: { name: string; children?: React.Reac
                       type="text"
                       label="Option Name"
                     />
-                    <Input name={`${name}.values[${index}].value`} defaultValue={1} type="number" label="Probability" />
+                    <Input name={`${name}.values[${index}].value`} defaultValue={1} step={0.01} type="number" label="Probability" />
                     <button type="button" onClick={() => remove(index)} className="bg-slate-400">
                       Remove
                     </button>


### PR DESCRIPTION
Add a step of 0.01 to the input so it allows to specify decimals in the probability input

Fixes https://github.com/AutomatedProcessImprovement/pix-portal/issues/80