### PR TITLE
Update Prosimos worker to read the starting date from the correct field

### DIFF
--- a/backend/workers/simulation-prosimos/simulation_prosimos/prosimos_service.py
+++ b/backend/workers/simulation-prosimos/simulation_prosimos/prosimos_service.py
@@ -45,7 +45,7 @@ def _prosimos_configuration_from_simulation_model(simulation_model_path: Path) -
 
     config = ProsimosConfiguration(
         total_cases=simulation_model.get("total_cases", 1000),
-        starting_at=simulation_model.get("starting_at", datetime.now(tz=timezone.utc)),
+        starting_at=simulation_model.get("start_time", datetime.now(tz=timezone.utc)),
         is_event_added_to_log=simulation_model.get("is_event_added_to_log", False),
     )
     return config


### PR DESCRIPTION
The interface stores the simulation start date in the "start_date" field in the JSON, but the worker was trying to read the value from the "starting_at" field.

Fixes #84 